### PR TITLE
Keypad opcodes

### DIFF
--- a/src/interpreter/instructions.rs
+++ b/src/interpreter/instructions.rs
@@ -230,8 +230,11 @@ impl Interpreter {
     ///
     /// Skips the next instruction if the key stored in `VX` is NOT pressed
     pub(super) fn skip_on_key_not_pressed(&mut self, x_register_index: usize) {
-        // TODO Daniel. ExA1: Key Up
-        println!("SKIP ON KEY NOT PRESSED!!!");
+        let key = self.variable_register[x_register_index] as usize;
+
+        if !self.keypad[key] {
+            self.program_counter += 2;
+        }
     }
 
     /// Opcode: Fx07

--- a/src/interpreter/instructions.rs
+++ b/src/interpreter/instructions.rs
@@ -218,7 +218,7 @@ impl Interpreter {
     ///
     /// Skips the next instruction if the key stored in `VX` is pressed
     pub(super) fn skip_on_key_pressed(&mut self, x_register_index: usize) {
-        // TODO Ex9E: Key Down
+        // TODO Daniel. Ex9E: Key Down
         println!("SKIP ON KEY PRESSED!!!");
     }
 
@@ -226,7 +226,7 @@ impl Interpreter {
     ///
     /// Skips the next instruction if the key stored in `VX` is NOT pressed
     pub(super) fn skip_on_key_not_pressed(&mut self, x_register_index: usize) {
-        // TODO ExA1: Key Up
+        // TODO Daniel. ExA1: Key Up
         println!("SKIP ON KEY NOT PRESSED!!!");
     }
 
@@ -241,7 +241,7 @@ impl Interpreter {
     ///
     /// A key press is awaited, and then stored in `VX`
     pub(super) fn wait_for_key_press(&mut self, x_register_index: usize) {
-        // TODO Fx0A: Wait
+        // TODO Daniel. Fx0A: Wait
         println!("WAIT FOR KEY PRESS!!!");
     }
 

--- a/src/interpreter/instructions.rs
+++ b/src/interpreter/instructions.rs
@@ -254,7 +254,7 @@ impl Interpreter {
             .position(|&is_key_pressed| is_key_pressed)
         {
             Some(key) => self.variable_register[x_register_index] = key as u8,
-            None => self.program_counter += 2,
+            None => self.program_counter -= 2,
         }
     }
 

--- a/src/interpreter/instructions.rs
+++ b/src/interpreter/instructions.rs
@@ -219,8 +219,11 @@ impl Interpreter {
     ///
     /// Skips the next instruction if the key stored in `VX` is pressed
     pub(super) fn skip_on_key_pressed(&mut self, x_register_index: usize) {
-        // TODO Daniel. Ex9E: Key Down
-        println!("SKIP ON KEY PRESSED!!!");
+        let key = self.variable_register[x_register_index] as usize;
+
+        if self.keypad[key] {
+            self.program_counter += 2;
+        }
     }
 
     /// Opcode: ExA1

--- a/src/interpreter/instructions.rs
+++ b/src/interpreter/instructions.rs
@@ -109,7 +109,7 @@ impl Interpreter {
     ///
     /// Adds `VY` to `VX`. `variable_register[0xF]` is set to 1 when there's an overflow, and to 0 when there is not
     pub(super) fn add_assign(&mut self, x_register_index: usize, y_register_index: usize) {
-        // TODO 8xy4: +=
+        // TODO Jacob. 8xy4: +=
         println!("ADD ASSIGN!!!");
     }
 
@@ -117,7 +117,7 @@ impl Interpreter {
     ///
     /// `VY` is subtracted from `VX`. `variable_register[0xF]` is set to 0 when there's an underflow, and 1 when there is not
     pub(super) fn sub_assign(&mut self, x_register_index: usize, y_register_index: usize) {
-        // TODO 8xy5: -=
+        // TODO Jacob. 8xy5: -=
         println!("SUBTRACT ASSIGN!!!");
     }
 
@@ -125,7 +125,7 @@ impl Interpreter {
     ///
     /// Stores the least significant bit of `VX` in `variable_register[0xF]` and then shifts `VX` to the right by 1
     pub(super) fn right_shift_assign(&mut self, x_register_index: usize, y_register_index: usize) {
-        // TODO 8xy6: >>=
+        // TODO Jacob. 8xy6: >>=
         println!("RIGHT SHIFT!!!");
     }
 
@@ -133,14 +133,15 @@ impl Interpreter {
     ///
     /// Sets `VX` to `VY` minus `VX`. `variable_register[0xF]` is set to 0 when there's an underflow, and 1 when there is not
     pub(super) fn sub_assign_swapped(&mut self, x_register_index: usize, y_register_index: usize) {
-        unimplemented!();
+        // TODO Jacob. 8xy7: -= swapped
+        println!("SUBTRACT ASSIGN SWAPPED!!!");
     }
 
     /// Opcode: 8xyE
     ///
     /// Stores the most significant bit of `VX` in `variable_register[0xF]` and then shifts `VX` to the left by 1
     pub(super) fn left_shift_assign(&mut self, x_register_index: usize, y_register_index: usize) {
-        // TODO 8xyE: <<=
+        // TODO Jacob. 8xyE: <<=
         println!("LEFT SHIFT!!!");
     }
 

--- a/src/interpreter/instructions.rs
+++ b/src/interpreter/instructions.rs
@@ -248,8 +248,14 @@ impl Interpreter {
     ///
     /// A key press is awaited, and then stored in `VX`
     pub(super) fn wait_for_key_press(&mut self, x_register_index: usize) {
-        // TODO Daniel. Fx0A: Wait
-        println!("WAIT FOR KEY PRESS!!!");
+        match self
+            .keypad
+            .iter()
+            .position(|&is_key_pressed| is_key_pressed)
+        {
+            Some(key) => self.variable_register[x_register_index] = key as u8,
+            None => self.program_counter += 2,
+        }
     }
 
     /// Opcode: Fx15


### PR DESCRIPTION
Implemented the three keypad opcodes:
Ex9E skip_on_key_pressed.
ExA1 skip_on_key_not_pressed.
Fx0A wait_for_key_press.
